### PR TITLE
ci: fix workflow publish

### DIFF
--- a/.github/workflows/publish-github-packages.yml
+++ b/.github/workflows/publish-github-packages.yml
@@ -17,13 +17,13 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: '16'
           registry-url: https://npm.pkg.github.com/
+          always-auth: true
 
       - run: yarn install --frozen-lockfile
       - run: yarn test ui
       - run: yarn build ui
-      - run: cd ${GITHUB_WORKSPACE}/dist/libs/ui
-      - run: yarn publish
+      - run: yarn publish ${GITHUB_WORKSPACE}/dist/libs/ui
         env:
           NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
set actions/setup-node@v3 always-auth to true